### PR TITLE
feat: add returned data from hooks | fix: typo useWS

### DIFF
--- a/sdks/hooks/api/use-ws.mdx
+++ b/sdks/hooks/api/use-ws.mdx
@@ -21,7 +21,7 @@ Subscribing to the `trade` topic:
 const ws = useWS();
 
 useEffect(() => {
-  const unsubscripe = ws.subscribe(
+  const unsubscribe = ws.subscribe(
     {
       id: `${symbol}@trade`,
       event: "subscribe",

--- a/sdks/hooks/assets/use-holding-stream.mdx
+++ b/sdks/hooks/assets/use-holding-stream.mdx
@@ -11,3 +11,15 @@ Receive current user holdings and auto update via Websockets.
 ```ts
 const { usdc } = useHoldingStream();
 ```
+
+The USDC object contains:
+
+```ts
+{
+  frozen: 0,
+  holding: 100,
+  pending_short: 0,
+  token: "USDC",
+  updated_time: 1732754429399
+}
+```

--- a/sdks/hooks/market-data/use-market-trade-stream.mdx
+++ b/sdks/hooks/market-data/use-market-trade-stream.mdx
@@ -6,6 +6,19 @@ Subscribe to [trades](/sdks/tech-doc/interfaces/orderly_network_types.API.Trade)
 
 - [Tech docs](/sdks/tech-doc/modules/orderly_network_hooks#usemkarettradestream)
 
+### Example
+
 ```tsx
 const { data, isLoading } = useMarketTradeStream(symbol);
+```
+
+The returned data is an array of objects containing the following fields:
+
+```ts
+{
+  "price": 95731.5,
+  "side": "SELL",
+  "size": 0.1,
+  "ts": 1732805310368
+}
 ```

--- a/sdks/hooks/market-data/use-markets-stream.mdx
+++ b/sdks/hooks/market-data/use-markets-stream.mdx
@@ -11,3 +11,26 @@ Subscribe to all [tickers](/sdks/tech-doc/interfaces/orderly_network_types.WSMes
 ```ts
 const { data } = useMarketsStream();
 ```
+
+The returned data is an array of objects containing the following fields:
+
+```ts
+{
+  "24h_amount": 48108.464865,
+  "24h_close": 0.04286,
+  "24h_high": 0.044604,
+  "24h_low": 0.042574,
+  "24h_open": 0.042944,
+  "24h_volume": 1096083,
+  "24h_volumn": 1096083,
+  "change": 0.00195,
+  "est_funding_rate": 0.00012004,
+  "index_price": 0.042851,
+  "last_funding_rate": 0.0002316,
+  "mark_price": 0.042877,
+  "next_funding_time": 1732809600000,
+  "open_interest": 571430,
+  "sum_unitary_funding": 0.00118,
+  "symbol": "PERP_1000BONK_USDC"
+}
+```

--- a/sdks/hooks/referral/use-daily.mdx
+++ b/sdks/hooks/referral/use-daily.mdx
@@ -6,6 +6,18 @@ Returns `perp_volume` based on start and end time. If not passed, defaults to la
 
 - [Tech docs](/sdks/tech-doc/modules/orderly_network_hooks#usedaily)
 
+### Example
+
 ```ts
 const { data } = useDaily();
+```
+
+The returned data is an array of objects containing the following fields:
+
+```ts
+{
+  "broker_id": "veeno_dex",
+  "date": "2024-11-11",
+  "perp_volume": 500
+}
 ```


### PR DESCRIPTION
Adding the returned data from hooks on the doc to help developers to quickly have access to the data returned using hook.
Fix a typo issue on useWS hook