### PR TITLE
Fix and improve Python example in "Account Registration" (missing imports and output)

### DIFF
--- a/build-on-omnichain/user-flows/accounts.mdx
+++ b/build-on-omnichain/user-flows/accounts.mdx
@@ -71,11 +71,15 @@ String registrationNonce = nonceObj.getJSONObject("data").getString("registratio
 
 ```py Python
 import requests
+import json
 
 BASE_URL = "https://testnet-api.orderly.org"
 
 res = requests.get(f"{BASE_URL}/v1/registration_nonce")
-print(res.text)
+response = json.loads(res.text)
+nonce = response["data"]["registration_nonce"]
+
+print(nonce)
 ```
 
 ```ts TypeScript

--- a/build-on-omnichain/user-flows/accounts.mdx
+++ b/build-on-omnichain/user-flows/accounts.mdx
@@ -70,11 +70,12 @@ String registrationNonce = nonceObj.getJSONObject("data").getString("registratio
 ```
 
 ```py Python
-base_url = "https://testnet-api.orderly.org"
+import requests
 
-res = requests.get("%s/v1/registration_nonce" % base_url)
-response = json.loads(res.text)
-registration_nonce = response["data"]["registration_nonce"]
+BASE_URL = "https://testnet-api.orderly.org"
+
+res = requests.get(f"{BASE_URL}/v1/registration_nonce")
+print(res.text)
 ```
 
 ```ts TypeScript


### PR DESCRIPTION
## Description
This PR updates the Python code example in User Flows > Accounts > Account Registration > 3. Obtain a registration nonce section of the documentation.

## Problem

The current code example:

- Lacks necessary imports, such as `requests` and `json`
- Does not print or return the nonce, which is the expected output of this step

## Fix

I replaced the current code snippet with a working and cleaner version:

```python
import requests

BASE_URL = "https://testnet-api.orderly.org"

res = requests.get(f"{BASE_URL}/v1/registration_nonce")
print(res.text)
```

**This version:**

- Adds the required import for requests
- Uses `f-string` formatting for better readability
- Includes a `print()` so users can immediately see the nonce value returned by the endpoint

Let me know if you'd like me to also include `json.loads()` to parse the response and print just the nonce key.
